### PR TITLE
Also check .lessignore for absolute file names, resolved with realpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ vimcolor -L (this command is valid both for vimcolor and nvimpager)
  or when the log file colorizer `tspin` was called for log files,
  a single colon has to be given to the less call as the second argument.
  It can also be achieved by listing such files in a file `.lessignore` in the
- users home directory. The entries are fully specified path names or contain
- globbing characters. Such a file could look as follows:
+ users home directory. The entries are relative or absolute path names or can
+ contain globbing characters. Such a file could look as follows:
 
 ```
  syslog

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -1000,14 +1000,17 @@ if [[ -z "$1" && "$0" == */lesspipe.sh ]]; then
 		echo "export LESSOPEN"
 	fi
 else
-	# no filtering for file names contained in .lessignore
+	# no filtering for file names contained in .lessignore, check given parameter + resolved absolute path
 	if [[ -r "${HOME}/.lessignore" ]]; then
-		name="$1"
+		rawfilename="$1"
+		resolvedname=$(realpath "$rawfilename" 2>/dev/null)
 		while IFS= read -r pattern || [[ -n "$pattern" ]]; do
 			[[ -z "$pattern" ]] && continue
 			[[ "$pattern" == \#* ]] && continue
 			# shellcheck disable=SC2053
-			[[ "$name" == $pattern ]] && exit 0
+			[[ "$rawfilename" == $pattern ]] && exit 0
+			# shellcheck disable=SC2053
+			[[ "$resolvedname" == $pattern ]] && exit 0
 		done < "${HOME}/.lessignore"
 	fi
 	[[ -x "${HOME}/.lessfilter" ]] && "${HOME}/.lessfilter" "$1" && exit "$retval"


### PR DESCRIPTION
Before this patch the entries in .lessignore were compared against a file parameter given to less on the commandline, globbing applied.

But what was not done is checking the absolute path of the resulting file. So consider you had `/var/log/messages` in your `.lessignore` file, your current working directory is `/var/log` and you now call `less messages`. Before this patch, the file would be passed through colorization and so on, losing the ability to use the follow (F) mode.

With this patch the relative filename as given on the commandline is compared as before. Additionally the absolute path is resolved and also compared, with globbing applied too.