### PR TITLE
Add support for a global /etc/lessignore file in addition to ${HOME}/.lessignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ vimcolor -L (this command is valid both for vimcolor and nvimpager)
  or when the log file colorizer `tspin` was called for log files,
  a single colon has to be given to the less call as the second argument.
  It can also be achieved by listing such files in a file `.lessignore` in the
- users home directory. The entries are fully specified path names or contain
- globbing characters. Such a file could look as follows:
+ users home directory. The entries are relative or absolute path names or can
+ contain globbing characters. Such a file could look as follows:
 
 ```
  syslog

--- a/README.md
+++ b/README.md
@@ -367,7 +367,8 @@ vimcolor -L (this command is valid both for vimcolor and nvimpager)
  or when the log file colorizer `tspin` was called for log files,
  a single colon has to be given to the less call as the second argument.
  It can also be achieved by listing such files in a file `.lessignore` in the
- users home directory. The entries are relative or absolute path names or can
+ users home directory or `/etc/lessignore`. The file in the users home dir
+ has precedence. The entries are relative or absolute path names or can
  contain globbing characters. Such a file could look as follows:
 
 ```

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -1000,14 +1000,17 @@ if [[ -z "$1" && "$0" == */lesspipe.sh ]]; then
 		echo "export LESSOPEN"
 	fi
 else
-	# no filtering for file names contained in .lessignore
+	# no filtering for file names contained in .lessignore, check given parameter + resolved absolute path
 	if [[ -r "${HOME}/.lessignore" ]]; then
-		name="$1"
+		rawfilename="$1"
+		resolvedname=$(realpath "$rawfilename" 2>/dev/null)
 		while IFS= read -r pattern || [[ -n "$pattern" ]]; do
 			[[ -z "$pattern" ]] && continue
 			[[ "$pattern" == \#* ]] && continue
 			# shellcheck disable=SC2053
-			[[ "$name" == $pattern ]] && exit 0
+			[[ "$rawfilename" == $pattern ]] && exit 0
+			# shellcheck disable=SC2053
+			[[ "$resolvedname" == $pattern ]] && exit 0
 		done < "${HOME}/.lessignore"
 	fi
 	[[ -x "${HOME}/.lessfilter" ]] && "${HOME}/.lessfilter" "$1" && exit "$retval"

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -419,7 +419,7 @@ get_unpack_cmd () {
 analyze_args () {
 	# determine how we are called
 	cmdtree=$(ps -oargs= 2>/dev/null)
-	[[ $cmdtree == *perldoc\ * ]] && exit 0
+	[[ $cmdtree == *perldoc\ * ]] && exit "$retval"
 	while read -r line; do
 		arg1=${line%% *}; arg1=${arg1##*/}
 		[[ $arg1 == less ]] && lessarg=$line
@@ -427,8 +427,8 @@ analyze_args () {
 	# last argument starting with colon or equal sign is used for piping into less
 	[[ $lessarg == *\ [:=]* ]] && fext=${lessarg#*[:=]}
 	# return if we want to watch growing files
-	[[ $lessarg == *less\ *\ : ]] && exit 0
-	[[ $lessarg == *less\ *\+F\ * && $fext != log ]] && exit 0
+	[[ $lessarg == *less\ *\ : ]] && exit "$retval"
+	[[ $lessarg == *less\ *\+F\ * && $fext != log ]] && exit "$retval"
 	# color is set when calling less with -r or -R or LESS contains that option
 	COLOR="--color=auto"
 	colors=0
@@ -982,9 +982,9 @@ trap 'rm -rf "$tmpdir"; exit 1' SIGINT
 trap 'rm -rf "$tmpdir"' EXIT
 trap - PIPE
 
+[[ $LESSOPEN == *\|\|* ]] && retval=1 || retval=0
 analyze_args
 # make LESSOPEN="|- ... " work
-[[ $LESSOPEN == *\|\|* ]] && retval=1 || retval=0
 if [[ $LESSOPEN == *\|-* && $1 == - ]]; then
 	t=$(nexttmp)
 	cat > "$t"
@@ -1008,9 +1008,9 @@ else
 			[[ -z "$pattern" ]] && continue
 			[[ "$pattern" == \#* ]] && continue
 			# shellcheck disable=SC2053
-			[[ "$rawfilename" == $pattern ]] && exit 0
+			[[ "$rawfilename" == $pattern ]] && exit "$retval"
 			# shellcheck disable=SC2053
-			[[ "$resolvedname" == $pattern ]] && exit 0
+			[[ "$resolvedname" == $pattern ]] && exit "$retval"
 		done < "${HOME}/.lessignore"
 	fi
 	[[ -x "${HOME}/.lessfilter" ]] && "${HOME}/.lessfilter" "$1" && exit "$retval"

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -1001,18 +1001,22 @@ if [[ -z "$1" && "$0" == */lesspipe.sh ]]; then
 	fi
 else
 	# no filtering for file names contained in .lessignore, check given parameter + resolved absolute path
-	if [[ -r "${HOME}/.lessignore" ]]; then
-		rawfilename="$1"
-		resolvedname=$(realpath "$rawfilename" 2>/dev/null)
-		while IFS= read -r pattern || [[ -n "$pattern" ]]; do
-			[[ -z "$pattern" ]] && continue
-			[[ "$pattern" == \#* ]] && continue
-			# shellcheck disable=SC2053
-			[[ "$rawfilename" == $pattern ]] && exit "$retval"
-			# shellcheck disable=SC2053
-			[[ "$resolvedname" == $pattern ]] && exit "$retval"
-		done < "${HOME}/.lessignore"
-	fi
+	# check "${HOME}/.lessignore" and global "/etc/lessignore", just process the first file found, do not mix them
+	for lessignore_file in "${HOME}/.lessignore" "/etc/lessignore"; do
+		if [[ -r "$lessignore_file" ]]; then
+			rawfilename="$1"
+			resolvedname=$(realpath "$rawfilename" 2>/dev/null)
+			while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+				[[ -z "$pattern" ]] && continue
+				[[ "$pattern" == \#* ]] && continue
+				# shellcheck disable=SC2053
+				[[ "$rawfilename" == $pattern ]] && exit "$retval"
+				# shellcheck disable=SC2053
+				[[ "$resolvedname" == $pattern ]] && exit "$retval"
+			done < "$lessignore_file"
+			break
+		fi
+	done
 	[[ -x "${HOME}/.lessfilter" ]] && "${HOME}/.lessfilter" "$1" && exit "$retval"
 	if has_cmd lessfilter; then
 		lessfilter "$1" && exit "$retval"


### PR DESCRIPTION
The ${HOME}/.lessignore has precedence and if it exists, /etc/lessignore is not
used. This prevents any kind mixing of the two files.
    
Having a global /etc/lessignore makes it easy to distribute a common setup that
excludes things like /var/log/syslog, /var/log/messages and the like per default,
while still allowing user overrides.

Apply this pull request after https://github.com/wofr06/lesspipe/pull/208
to prevent conflicts.